### PR TITLE
CI for toolshed linting and uploading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         - set -e
         - |
           if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
-              while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              # while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
               while read -r DIR; do planemo shed_update --shed_target toolshed --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
           fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+sudo: required
+cache: pip
+language: python
+
+python: 3.7
+
+jobs:
+  include:
+    - stage: test
+    - stage: deploy
+      if: (type = push) AND (branch = master)
+      addons: {}
+      before_install: skip
+      script:
+        - planemo --version
+        - git diff --quiet "$TRAVIS_COMMIT_RANGE" -- ; GIT_DIFF_EXIT_CODE=$?
+        - |
+          if [ "$GIT_DIFF_EXIT_CODE" -gt 1 ] ; then
+              git remote set-branches --add origin master
+              git fetch
+              TRAVIS_COMMIT_RANGE=origin/master...
+          fi
+        - echo $TRAVIS_COMMIT_RANGE
+        - |
+          planemo ci_find_repos --changed_in_commit_range "$TRAVIS_COMMIT_RANGE" \
+                                --output changed_repositories.list
+        - cat changed_repositories.list
+        - set -e
+        - |
+          if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
+              while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_key "$TEST_SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+              while read -r DIR; do planemo shed_update --shed_target toolshed --shed_key "$SHED_KEY" --force_repository_creation "$DIR" || exit 1; done < changed_repositories.list
+          fi
+
+before_script:
+- pip install planemo
+
+script:
+- planemo lint -r --report_level error tools
+
+notifications:
+  email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 - pip install planemo
 
 script:
-- planemo lint -r --report_level error tools
+- planemo lint -r --report_level error flowtools
 
 notifications:
   email: false

--- a/flowtools/cs_overview/crossSampleOverview.xml
+++ b/flowtools/cs_overview/crossSampleOverview.xml
@@ -44,7 +44,7 @@
           <element name="input3.flowclr" value="input3.flowclr"/>
         </collection>
       </param>
-      <output name="output_file" file="out.html" compare="sim_size">
+      <output name="html_file" file="out.html" compare="sim_size">
         <extra_files type="file" name="csAllMFIs.tsv" value="csAllMFIs.tsv"/>
         <extra_files type="file" name="csOverview.tsv" value="csOverview.tsv"/>
         <extra_files type="file" name="csBoxplotData.json" value="csBoxplotData.json" compare="contains"/>

--- a/flowtools/edit_fcs_markers/editFCSmarkers.xml
+++ b/flowtools/edit_fcs_markers/editFCSmarkers.xml
@@ -44,7 +44,7 @@
       <param name="corm" value="M"/>
       <param name="outformat" value="flowFrame"/>
       <output name="report" value="report1.txt"/>
-      <output name="output" file="output.flowframe" compare="sim_size" delta="500000"/>
+      <output name="output_file" file="output.flowframe" compare="sim_size" delta="500000"/>
     </test>
     <test>
       <param name="input" value="input.fcs"/>
@@ -53,7 +53,7 @@
       <param name="corm" value="C"/>
       <param name="outformat" value="FCS"/>
       <output name="report" value="report2.txt"/>
-      <output name="output" file="output.fcs" compare="sim_size" delta="500000"/>
+      <output name="output_file" file="output.fcs" compare="sim_size" delta="500000"/>
     </test>
   </tests>
   <help><![CDATA[

--- a/flowtools/flow_overview/genFlowOverview.xml
+++ b/flowtools/flow_overview/genFlowOverview.xml
@@ -49,7 +49,7 @@
       <param name="input" value="input.flowclr"/>
       <param name="mfi" value="mfi"/>
       <param name="runcl" value="no"/>
-      <output name="output_file" file="out1/out.html" compare="sim_size">
+      <output name="html_file" file="out1/out.html" compare="sim_size">
         <extra_files type="file" name="flow.mfi" value="out1/flow.mfi"/>
         <extra_files type="file" name="flow.mfi_pop" value="out1/flow.mfi_pop"/>
         <extra_files type="file" name="flow.overview" value="out1/flow.overview"/>
@@ -66,7 +66,7 @@
       <param name="mfi" value="mfi"/>
       <param name="runcl" value="yes"/>
       <param name="scores" value="profile.flowscore"/>
-      <output name="output_file" file="out2/out.html" compare="sim_size">
+      <output name="html_file" file="out2/out.html" compare="sim_size">
         <extra_files type="file" name="boxplot.json" value="out2/boxplotData.json" compare="contains"/>
         <extra_files type="file" name="CLprofiles.txt" value="out2/CLprofiles.txt"/>
         <extra_files type="file" name="flow.mfi" value="out2/flow.mfi"/>


### PR DESCRIPTION
This PR adds travis-ci integration to enable toolshed linting of the tools and uploading to the main galaxy toolshed when the PRs are merged to master. This will require that the owner of this repo, I presume @cristhomas, adds to Travis the needed keys for the immport Galaxy toolshed user immport-devteam, and turn this on on travis-ci.com. If this is too much problem, if I get added to your github organization, I could do this for you on travis-ci.com. Please let me know if you need directions to know how to add the toolshed keys for test-toolshed and the main toolshed for the user in question. Thanks!